### PR TITLE
Add build/ and dist/ directories to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 *.egg-info
 *.csv
 __pycache__/*
+build/
+dist/


### PR DESCRIPTION
These directories are built when running the installer. They shouldn't be in the repository.
