### PR TITLE
Add Pending-SHA-Update column

### DIFF
--- a/gh2/csv.py
+++ b/gh2/csv.py
@@ -177,7 +177,7 @@ def write_rows(filename, headers, fields, issues, date_format, include_prs,
 def set_headers(repo, labels=None):
     headers = [
         'ID', 'Link', 'Name', 'Backlog', 'Approved', 'Doing',
-        'Needs Review', 'Dev Done'
+        'Needs Review', 'Pending SHA Update',  'Dev Done'
     ]
     if labels:
        headers.extend('Label: ' + label.name for label in labels)
@@ -210,6 +210,7 @@ def main():
         'label:status-approved:created_at',
         'label:status-doing:created_at',
         'label:status-needs-review:created_at',
+        'label:status-pending-sha-update:created_at',
         'closed_at',
     ]
 


### PR DESCRIPTION
The Waffle board [1] includes the column 'Pending SHA update' and is
sited between 'Needs review' and 'Done'. This column is represented by
the label 'status-pending-sha-update' in GitHub.

This commit updates the output from gh2csv to include the date and time
when this label was added so that it is properly represented when
analysing the data.

[1] https://waffle.io/rcbops/u-suk-dev

Connected https://github.com/rcbops/u-suk-dev/issues/484
