### PR TITLE
Add persistent caching of API responses

### DIFF
--- a/gh2/csv.py
+++ b/gh2/csv.py
@@ -7,6 +7,8 @@ import csv
 import itertools
 import os
 
+import cachecontrol
+import cachecontrol.caches
 import github3
 
 
@@ -56,8 +58,13 @@ def make_parser():
     return args
 
 
-def get_repo(owner, name, token):
+def get_repo(owner, name, token, cache_path='~/.gh2/cache'):
+    cache_path = os.path.expanduser(cache_path)
+
     gh = github3.GitHub(token=token)
+    gh.session = cachecontrol.CacheControl(
+        gh.session, cache=cachecontrol.caches.FileCache(cache_path)
+    )
     return gh.repository(owner, name)
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ import sys
 
 
 install_requires = [
-    "github3.py >= 1.0.0a1"
+    "github3.py >= 1.0.0a1",
+    "cachecontrol[filecache]",
 ]
 
 if sys.version_info[:2] < (2, 7):


### PR DESCRIPTION
Add file-based caching to gh2. This reduces the number of API requests,
that count toward the API rate limit, that need to be made by using
cachecontrol to store the data from previous requests and manage changes
using ETags.

Recent additions to gh2, such as label support, has increased the number
of API requests that are being made causing rate limits to be hit more
frequently. Without a mechanism to reduce the number of API requests
that are counted by the rate limit, gh2 can be difficult to use without
impacting general use of GitHub.

Connected https://github.com/rcbops/u-suk-dev/issues/489